### PR TITLE
fix #15: allow calling invalidateTags() multiple times with expected behavior

### DIFF
--- a/src/Cache/LSCacheTagsInvalidator.php
+++ b/src/Cache/LSCacheTagsInvalidator.php
@@ -17,10 +17,10 @@ class LSCacheTagsInvalidator implements CacheTagsInvalidatorInterface {
      * Variable to store tags to invalidate when $cacheCheck = 1
      */
 
-    public static $tags;
+    public static $tags = array();
 
     /**
-     * Variable to store tags to invalidate when $cacheCheck = 1
+     * If $purgeAllByTags = 1 LiteSpeedCacheSubscriber will invalidate whole website with $commonTag
      */
 
     public static $purgeAllByTags;
@@ -39,23 +39,25 @@ class LSCacheTagsInvalidator implements CacheTagsInvalidatorInterface {
 
         // check if its purge all tag
 
-        $finalTags = [];
-
         $commonTag = substr(md5(DRUPAL_ROOT),0,5);
 
-        foreach ($tags as $val) {
-            if (strpos($val, 'config') !== false or ($val == "http_response") or ($val == "rendered")) {
-                LSCacheTagsInvalidator::$purgeAllByTags = 1;
-                return;
-            }
-            else{
-                array_push($finalTags,$commonTag . '_' .$val);
-            }
+        if (LSCacheTagsInvalidator::$purgeAllByTags) {
+          return;
+        }
+        else {
+          foreach ($tags as $val) {
+              if (strpos($val, 'config') !== false or ($val == "http_response") or ($val == "rendered")) {
+                  LSCacheTagsInvalidator::$purgeAllByTags = 1;
+                  LSCacheTagsInvalidator::$cacheCheck = 0;
+                  return;
+              }
+              else{
+                  array_push(LSCacheTagsInvalidator::$tags,$commonTag . '_' .$val);
+              }
+          }
         }
 
-        LSCacheTagsInvalidator::$tags = $finalTags;
         LSCacheTagsInvalidator::$cacheCheck = 1;
     }
-
 
 }


### PR DESCRIPTION
The Drupal Cache::invalidateTags() function could be (and is typically) called multiple times during a single request/response. Original LSCacheTagsInvalidator::invalidateTags() did not take this into account, leading to unexpected cache purging behavior (cache was not purged).

As the LSCacheTagsInvalidator::invalidateTags() is only gathering invalidated tags and the actual cache purging is handled in LiteSpeedCacheSubscriber using response header, previous state of invalidateTags() should be remembered between calls.

This PR appends the cache tags to LSCacheTagsInvalidator::$tags instead overwriting it on every invalidateTags() call. Additionally the invalidateTags() now checks if LSCacheTagsInvalidator::$purgeAllByTags have been set previously and ensure it's not overwritten if set.