### PR TITLE
Update code for Drupal 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-LiteSpeed Cache for Drupal 8+
+LiteSpeed Cache for Drupal 9+
 ============================
 
-Drupal 8/9 is significantly changed from Drupal 7. They have converted from procedural programming to object-oriented programming. Drupal 8 has a built-in page cache (for static content) and a dynamic page cache for logged in users. The latter basically works as a reverse proxy written in PHP. The built-in proxy is good if you have no other options, however, with the LiteSpeed Cache plugin you will see a great improvement in performance for your Drupal 8 site.
+Drupal 9+ is significantly changed from Drupal 7. They have converted from procedural programming to object-oriented programming. Drupal 9+ has a built-in page cache (for static content) and a dynamic page cache for logged in users. The latter basically works as a reverse proxy written in PHP. The built-in proxy is good if you have no other options, however, with the LiteSpeed Cache plugin you will see a great improvement in performance for your Drupal 9+ site.
 
 See https://www.litespeedtech.com/products/cache-plugins for more information.
 
@@ -9,7 +9,7 @@ See https://www.litespeedtech.com/products/cache-plugins for more information.
 
 Prerequisites
 -------------
-This version of LiteSpeed Cache requires Drupal 8.xx or later and LiteSpeed Web Server (LSWS) 5.2.3 or later.
+This version of LiteSpeed Cache requires Drupal 9 or later and LiteSpeed Web Server (LSWS) 5.2.3 or later.
 
 
 
@@ -36,9 +36,11 @@ If you use Composer to manage dependencies, require the module in your project `
 Enable LiteSpeedCache using rewrite rules
 -------------
 
-    <IfModule LiteSpeed>
-	CacheLookup on
-    </IfModule>
+```
+<IfModule LiteSpeed>
+  CacheLookup on
+</IfModule>
+```
 
 Install Plugin
 -------------

--- a/lite_speed_cache.info.yml
+++ b/lite_speed_cache.info.yml
@@ -3,11 +3,4 @@ type: module
 description: 'Caches pages for any user, handling dynamic content correctly.'
 package: Core
 configure: lite_speed_cache.form
-core_version_requirement: ^8 || ^9
-# version: VERSION
-
-# Information added by Drupal.org packaging script on 2017-12-06
-version: '8.4.3'
-core: '8.x'
-project: 'drupal'
-datestamp: 1512600826
+core_version_requirement: ^9 || ^10 || ^11

--- a/lite_speed_cache.install
+++ b/lite_speed_cache.install
@@ -5,8 +5,6 @@
  * Installation functions for LiteSpeed Cache module.
  */
 
-use Drupal\user\RoleInterface;
-
 /**
  * Implements hook_install().
  */

--- a/lite_speed_cache.module
+++ b/lite_speed_cache.module
@@ -30,13 +30,3 @@ function lite_speed_cache_help($route_name, RouteMatchInterface $route_match) {
             return $output;
     }
 }
-
-
-/**
- * Implements hook_user_login($account).
- */
-
-
-function lite_speed_cache_user_login($account) {
-    $reqTemp = \Drupal::request();
-}

--- a/src/Cache/LSCacheTagsInvalidator.php
+++ b/src/Cache/LSCacheTagsInvalidator.php
@@ -8,7 +8,6 @@
 
 namespace Drupal\lite_speed_cache\Cache;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 
 class LSCacheTagsInvalidator implements CacheTagsInvalidatorInterface {

--- a/src/EventSubscriber/LiteSpeedCacheSubscriber.php
+++ b/src/EventSubscriber/LiteSpeedCacheSubscriber.php
@@ -9,14 +9,13 @@
 namespace Drupal\lite_speed_cache\EventSubscriber;
 
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Cache\CacheableResponseInterface;
 use Drupal\Core\PageCache\RequestPolicyInterface;
 use Drupal\Core\PageCache\ResponsePolicyInterface;
 use Drupal\Core\Render\RenderCacheInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use \Drupal\lite_speed_cache\Cache\LSCacheTagsInvalidator;
 use \Drupal\lite_speed_cache\Form\LSCacheForm;
@@ -122,10 +121,10 @@ class LiteSpeedCacheSubscriber implements EventSubscriberInterface {
     /**
      * Sets a response in case of a Dynamic Page Cache hit.
      *
-     * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
      *   The event to process.
      */
-    public function onRouteMatch(GetResponseEvent $event) {
+    public function onRouteMatch(RequestEvent $event) {
 
         // Don't cache the response if the Dynamic Page Cache request policies are
         // not met. Store the result in a static keyed by current request, so that
@@ -160,10 +159,10 @@ class LiteSpeedCacheSubscriber implements EventSubscriberInterface {
     /**
      * Stores a response in case of a Dynamic Page Cache miss, if cacheable.
      *
-     * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
      *   The event to process.
      */
-    public function onResponse(FilterResponseEvent $event){
+    public function onResponse(ResponseEvent $event){
         $response = $event->getResponse();
         $request = $event->getRequest();
 
@@ -240,7 +239,7 @@ class LiteSpeedCacheSubscriber implements EventSubscriberInterface {
                 $response->headers->set(self::STATUSHEADER, 'No Purge');
             }
         }
-        
+
         // wade:start
         // Check if it needs to crawler the sitemap
         if (LSCacheForm::$crawlerTheSite) {
@@ -250,7 +249,6 @@ class LiteSpeedCacheSubscriber implements EventSubscriberInterface {
             }
         }
         // wade:end
-        
 
         if ($request->cookies->has(session_name())) {
 
@@ -270,17 +268,14 @@ class LiteSpeedCacheSubscriber implements EventSubscriberInterface {
                 return;
             }
 
-
             $request = $event->getRequest();
             if (!isset($this->requestPolicyResults[$request])) {
                 return;
             }
 
-
             if ($this->requestPolicyResults[$request] === RequestPolicyInterface::DENY || $this->responsePolicy->check($response, $request) === ResponsePolicyInterface::DENY) {
                     return;
             }
-
 
             if($cacheStatus=='0' or $cacheStatus == 'On')  {
                 $response->headers->set('X-LiteSpeed-Cache-Control', 'private, max-age='.$maxAgePrivate);
@@ -290,7 +285,6 @@ class LiteSpeedCacheSubscriber implements EventSubscriberInterface {
                 $tags = implode(',', $tags);
                 $response->headers->set('X-LiteSpeed-Tag', $tags);
             }
-
 
         }else {
                 $cookies = $request->cookies;
@@ -303,7 +297,6 @@ class LiteSpeedCacheSubscriber implements EventSubscriberInterface {
         }
 
     }
-
 
     /**
      * Whether the given response should be cached by LiteSpeed Page Cache.
@@ -339,8 +332,6 @@ class LiteSpeedCacheSubscriber implements EventSubscriberInterface {
         return TRUE;
     }
 
-
-    /**
     /**
      * {@inheritdoc}
      */

--- a/src/EventSubscriber/LiteSpeedCacheSubscriber.php
+++ b/src/EventSubscriber/LiteSpeedCacheSubscriber.php
@@ -193,7 +193,7 @@ class LiteSpeedCacheSubscriber implements EventSubscriberInterface {
             if($lsCacheDebug=='0' or $lsCacheDebug == 'On') {
                 $response->headers->set(self::STATUSHEADER, 'LS Cache Purged!');
             }
-            $response->headers->set(LiteSpeedCacheSubscriber::PURGEHEADER, $commonTag);
+            $response->headers->set(self::PURGEHEADER, $commonTag);
         } else {
             if($lsCacheDebug=='0' or $lsCacheDebug == 'On') {
                 $response->headers->set(self::STATUSHEADER, 'No Purge!');
@@ -207,7 +207,7 @@ class LiteSpeedCacheSubscriber implements EventSubscriberInterface {
                 $response->headers->set(self::STATUSHEADER, 'LS Cache Purged!');
             }
             $tags = implode(",", LSCacheTagsInvalidator::$tags);
-            $response->headers->set(LiteSpeedCacheSubscriber::PURGEHEADER, $tags);
+            $response->headers->set(self::PURGEHEADER, $tags);
         } else {
             if($lsCacheDebug=='0' or $lsCacheDebug == 'On') {
                 $response->headers->set(self::STATUSHEADER, 'No Purge!');
@@ -220,7 +220,7 @@ class LiteSpeedCacheSubscriber implements EventSubscriberInterface {
             if($lsCacheDebug=='0' or $lsCacheDebug == 'On') {
                 $response->headers->set(self::STATUSHEADER, 'LS Cache Purged!');
             }
-            $response->headers->set(LiteSpeedCacheSubscriber::PURGEHEADER, "*");
+            $response->headers->set(self::PURGEHEADER, "*");
         } else {
             if($lsCacheDebug=='0' or $lsCacheDebug == 'On') {
                 $response->headers->set(self::STATUSHEADER, 'No Purge');
@@ -233,7 +233,7 @@ class LiteSpeedCacheSubscriber implements EventSubscriberInterface {
             if($lsCacheDebug=='0' or $lsCacheDebug == 'On') {
                 $response->headers->set(self::STATUSHEADER, 'LS Cache Purged!');
             }
-            $response->headers->set(LiteSpeedCacheSubscriber::PURGEHEADER, $commonTag);
+            $response->headers->set(self::PURGEHEADER, $commonTag);
         } else {
             if($lsCacheDebug=='0' or $lsCacheDebug == 'On') {
                 $response->headers->set(self::STATUSHEADER, 'No Purge');

--- a/src/Form/LSCacheForm.php
+++ b/src/Form/LSCacheForm.php
@@ -18,19 +18,16 @@ class LSCacheForm extends ConfigFormBase
     /**
      * Purge all status variable
      */
-
     public static $purgeALL;
 
     /**
      * Purge this site status variable
      */
-
     public static $purgeThisSite;
-        
+
     /**
     * crawlear this site variable
     */
-
     public static $crawlerTheSite;
 
     /**
@@ -48,7 +45,6 @@ class LSCacheForm extends ConfigFormBase
             'lite_speed_cache.settings','system.performance',
         ];
     }
-
 
     /**
      * {@inheritdoc}
@@ -105,21 +101,7 @@ class LSCacheForm extends ConfigFormBase
             '#description' => $this->t('Weather to send or not the debug headers!'),
         );
 
-
         $options = ['On','Off'];
-
-        /*
-
-        $form['cache_settings']['esi_on'] = array(
-            '#type' => 'select',
-            '#title' => $this->t('ESI'),
-            '#options' => $options,
-            '#default_value' => $config->get('lite_speed_cache.esi_on'),
-            '#description' => $this->t('Turn ESI On or Off for Hole Punching! Keep it disabled if you are on OpenLiteSpeed.'),
-        );
-
-        */
-
 
         // max_age field.
         $form['cache_settings']['max_age'] = array(
@@ -128,18 +110,6 @@ class LSCacheForm extends ConfigFormBase
             '#default_value' => $config->get('lite_speed_cache.max_age'),
             '#description' => $this->t('Amount of time for which page should be cached by LiteSpeed Webserver public cache (Seconds).'),
         );
-
-        /*
-
-        // max_age field.
-        $form['cache_settings']['max_age_private'] = array(
-            '#type' => 'textfield',
-            '#title' => $this->t('Max age private'),
-            '#default_value' => $config->get('lite_speed_cache.max_age_private'),
-            '#description' => $this->t('Amount of time for which page should be cached by LiteSpeed Webserver private cache.'),
-        );
-
-        */
 
         return $form;
     }
@@ -165,7 +135,7 @@ class LSCacheForm extends ConfigFormBase
         $config->set('lite_speed_cache.cache_status', $form_state->getValue('cache_status'));
         $config->set('lite_speed_cache.debug', $form_state->getValue('debug'));
         $config->save();
-        
+
         // Prevent gzip cause broken website layout
         $config = $this->config('system.performance');
         $config->set('css.preprocess', '0');

--- a/src/StackMiddleware/LiteSpeedCache.php
+++ b/src/StackMiddleware/LiteSpeedCache.php
@@ -8,13 +8,10 @@
 
 namespace Drupal\lite_speed_cache\StackMiddleware;
 
-use Drupal\Core\Cache\Cache;
 use Drupal\Core\Cache\CacheableResponseInterface;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\PageCache\RequestPolicyInterface;
 use Drupal\Core\PageCache\ResponsePolicyInterface;
-use Drupal\Core\Site\Settings;
-use Drupal\user\Authentication\Provider\Cookie;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -102,14 +99,14 @@ class LiteSpeedCache implements HttpKernelInterface {
      * {@inheritdoc}
      */
 
-    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = TRUE) {
+    public function handle(Request $request, $type = self::MAIN_REQUEST, $catch = TRUE):Response {
 
 
 
         if( (isset($_SERVER['X-LSCACHE']) && $_SERVER['X-LSCACHE']) || (isset($_SERVER['HTTP_X_LSCACHE']) && $_SERVER['HTTP_X_LSCACHE']) ){
 
             // Only allow page caching on master request.
-            if ($type === static::MASTER_REQUEST && $this->requestPolicy->check($request) === RequestPolicyInterface::ALLOW) {
+            if ($type === static::MAIN_REQUEST && $this->requestPolicy->check($request) === RequestPolicyInterface::ALLOW) {
                 $response = $this->lookup($request, $type, $catch);
             }
             else {
@@ -132,7 +129,7 @@ class LiteSpeedCache implements HttpKernelInterface {
      * @param \Symfony\Component\HttpFoundation\Request $request
      *   A request object.
      * @param int $type
-     *   The type of the request (one of HttpKernelInterface::MASTER_REQUEST or
+     *   The type of the request (one of HttpKernelInterface::MAIN_REQUEST or
      *   HttpKernelInterface::SUB_REQUEST)
      * @param bool $catch
      *   Whether to catch exceptions or not
@@ -140,7 +137,7 @@ class LiteSpeedCache implements HttpKernelInterface {
      * @returns \Symfony\Component\HttpFoundation\Response $response
      *   A response object.
      */
-    protected function pass(Request $request, $type = self::MASTER_REQUEST, $catch = TRUE) {
+    protected function pass(Request $request, $type = self::MAIN_REQUEST, $catch = TRUE) {
         return $this->httpKernel->handle($request, $type, $catch);
     }
 
@@ -150,7 +147,7 @@ class LiteSpeedCache implements HttpKernelInterface {
      * @param \Symfony\Component\HttpFoundation\Request $request
      *   A request object.
      * @param int $type
-     *   The type of the request (one of HttpKernelInterface::MASTER_REQUEST or
+     *   The type of the request (one of HttpKernelInterface::MAIN_REQUEST or
      *   HttpKernelInterface::SUB_REQUEST)
      * @param bool $catch
      *   Whether to catch exceptions or not
@@ -158,7 +155,7 @@ class LiteSpeedCache implements HttpKernelInterface {
      * @returns \Symfony\Component\HttpFoundation\Response $response
      *   A response object.
      */
-    protected function lookup(Request $request, $type = self::MASTER_REQUEST, $catch = TRUE) {
+    protected function lookup(Request $request, $type = self::MAIN_REQUEST, $catch = TRUE) {
 
 
         // fetch request from backend and set cache headers
@@ -218,7 +215,7 @@ class LiteSpeedCache implements HttpKernelInterface {
      * @param \Symfony\Component\HttpFoundation\Request $request
      *   A request object.
      * @param int $type
-     *   The type of the request (one of HttpKernelInterface::MASTER_REQUEST or
+     *   The type of the request (one of HttpKernelInterface::MAIN_REQUEST or
      *   HttpKernelInterface::SUB_REQUEST)
      * @param bool $catch
      *   Whether to catch exceptions or not
@@ -226,7 +223,7 @@ class LiteSpeedCache implements HttpKernelInterface {
      * @returns \Symfony\Component\HttpFoundation\Response $response
      *   A response object.
      */
-    protected function fetch(Request $request, $type = self::MASTER_REQUEST, $catch = TRUE) {
+    protected function fetch(Request $request, $type = self::MAIN_REQUEST, $catch = TRUE) {
         /** @var \Symfony\Component\HttpFoundation\Response $response */
         $response = $this->httpKernel->handle($request, $type, $catch);
 


### PR DESCRIPTION
The code has been updated to be compatible with Drupal 10, following changes to the version of Symfony that Drupal now uses and deprecated classes being removed. The main change is dropping support for Drupal 8, which no longer received security updates.

This also removes some unused code, to help with readability.

This has been tested on Drupal 9.4, 9.5 and Drupal 10.